### PR TITLE
Export mergeable status to dashboard

### DIFF
--- a/pastamaker/gh_pr.py
+++ b/pastamaker/gh_pr.py
@@ -142,6 +142,7 @@ def pastamaker_raw_data(self):
     data["pastamaker_weight"] = self.pastamaker_weight
     data["travis_state"] = self.travis_state
     data["travis_url"] = self.travis_url
+    data["mergeable"] = self.mergeable
     data["approvals"] = self.approvals
     return data
 

--- a/pastamaker/static/partials/table.html
+++ b/pastamaker/static/partials/table.html
@@ -29,6 +29,7 @@
          <th class="state"><span class="glyphicon glyphicon-file"></span></th>
          <th class="last-updated">Last updated</th>
          <th class="state" title="Indicates its status">CI</th>
+         <th class="mergeable" title="Mergeable status">Mergeable</th>
          <th class="reviews"><span class="glyphicon glyphicon-thumbs-up"></span></th>
          <th class="reviews"><span class="glyphicon glyphicon-thumbs-down"></span></th>
          <th class="queue">Weight</th>
@@ -52,7 +53,12 @@
                      <span ng-if="pull.travis_state == 'error'" title="Last test error!" class="bad glyphicon glyphicon-remove"></span>
                      <span ng-if="pull.travis_state == 'pending'" title="Latest test pending" class="maybe glyphicon glyphicon-time"></span>
                  </a>
-            </td>
+             </td>
+             <td class="mergeable">
+                     <span ng-if="pull.travis_state == true" title="Can be merged" class="good glyphicon glyphicon-ok"></span>
+                     <span ng-if="pull.travis_state == false" title="Cannot be merged" class="bad glyphicon glyphicon-remove"></span>
+                     <span ng-if="pull.travis_state == null" title="Unknown status" class="bad glyphicon glyphicon-question-sign"></span>
+             </td>
              <td class="reviews info">
                  <a ng-repeat="user in pull.approvals[0]"
                     href="{{ user.html_url }}"


### PR DESCRIPTION
GitHub exports a mergeable status that indicates if the PR needs e.g. a
rebasing because it has conflicts.
It'd be cool to see that in the dashboard.