### PR TITLE
Pass enforce_admins to protect

### DIFF
--- a/pastamaker/gh_branch.py
+++ b/pastamaker/gh_branch.py
@@ -101,4 +101,4 @@ def protect_if_needed(g_repo, branch):
     if not is_protected(g_repo, branch, enforce_admins):
         LOG.warning("Branch %s of %s is misconfigured, configuring it",
                     branch, g_repo.full_name, enforce_admins)
-        protect(g_repo, branch)
+        protect(g_repo, branch, enforce_admins)


### PR DESCRIPTION
TypeError: protect() takes exactly 3 arguments (2 given)
ERROR event handler failure
  File "/app/.heroku/python/lib/python2.7/site-packages/rq/worker.py", line 710, in perform_job
    rv = job.perform()
Traceback (most recent call last):
  File "/app/.heroku/python/lib/python2.7/site-packages/rq/job.py", line 560, in perform
    self._result = self._execute()
  File "/app/.heroku/python/lib/python2.7/site-packages/rq/job.py", line 566, in _execute
    return self.func(*self.args, **self.kwargs)
  File "/app/pastamaker/worker.py", line 43, in event_handler
    engine.PastaMakerEngine(g, user, repo).handle(event_type, data)
  File "/app/pastamaker/engine.py", line 103, in handle
    gh_branch.protect_if_needed(self._r, current_branch)
  File "/app/pastamaker/gh_branch.py", line 104, in protect_if_needed
    protect(g_repo, branch)
TypeError: protect() takes exactly 3 arguments (2 given)